### PR TITLE
Potential fix for code scanning alert no. 305: Implicit narrowing conversion in compound assignment

### DIFF
--- a/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
@@ -392,7 +392,7 @@ public abstract class Tensor {
   /** Calculates the number of elements in a tensor with the specified shape. */
   public static long numel(long[] shape) {
     checkShape(shape);
-    int result = 1;
+    long result = 1;
     for (long s : shape) {
       result *= s;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/305](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/305)

To fix the issue, the type of the variable `result` should be changed from `int` to `long`. This ensures that the multiplication operation in the loop does not result in an implicit narrowing conversion and avoids potential overflow. The change is localized to the `numel` method, and no additional imports or definitions are required. The return type of the method is already `long`, so no further changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
