### PR TITLE
Potential fix for code scanning alert no. 306: Incomplete regular expression for hostnames

### DIFF
--- a/benchmarks/dynamo/parse_logs.py
+++ b/benchmarks/dynamo/parse_logs.py
@@ -20,7 +20,7 @@ full_log = open(sys.argv[1]).read()
 
 # If the log contains a gist URL, extract it so we can include it in the CSV
 gist_url = ""
-m = re.search(r"https://gist.github.com/[a-f0-9]+", full_log)
+m = re.search(r"https://gist\.github\.com/[a-f0-9]+", full_log)
 if m is not None:
     gist_url = m.group(0)
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/306](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/306)

To fix the issue, the `.` in the regular expression should be escaped with a backslash (`\.`) to ensure it matches a literal dot instead of any character. This change will make the regular expression more precise and prevent unintended matches. The updated pattern will be `https://gist\.github\.com/[a-f0-9]+`.

The change should be made on line 23 of the file `benchmarks/dynamo/parse_logs.py`. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
