### PR TITLE
Potential fix for code scanning alert no. 304: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -5836,6 +5836,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_13-xpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_13-xpu-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/304](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/304)

To fix the issue, we will add an explicit `permissions` block to the `wheel-py3_13-xpu-test` job. Based on the operations performed in the job, the minimal required permissions appear to be `contents: read`. This ensures that the job has only the necessary access to repository contents and does not inadvertently inherit broader permissions.

The changes will be made to the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_13-xpu-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
