### PR TITLE
Potential fix for code scanning alert no. 302: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -5599,6 +5599,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_13-cuda12_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_13-cuda12_6-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/302](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/302)

To fix the issue, we need to add an explicit `permissions` block to the `wheel-py3_13-cuda12_6-test` job. Since this job is primarily for testing, it likely only requires `contents: read` permissions. This change adheres to the principle of least privilege and ensures that the job does not inherit excessive permissions from the repository.

The fix involves:
1. Adding a `permissions` block to the `wheel-py3_13-cuda12_6-test` job.
2. Setting the permissions to `contents: read`, which is the minimal required permission for most CI workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
