### PR TITLE
Potential fix for code scanning alert no. 283: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   get-conclusion:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       conclusion: ${{ fromJson(steps.get-conclusion.outputs.data).conclusion }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/283](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/283)

To fix the issue, we need to explicitly define the permissions for the `get-conclusion` job. Since this job only reads data from the GitHub API, it requires `contents: read` permissions. Adding this permission ensures that the `GITHUB_TOKEN` used in the job has the minimum access necessary to perform its tasks.

The changes will involve:
1. Adding a `permissions` block to the `get-conclusion` job with `contents: read`.
2. Ensuring no unnecessary permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
