### PR TITLE
Potential fix for code scanning alert no. 288: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -57,6 +57,8 @@ jobs:
     if: github.repository_owner == 'pytorch'
     name: win-vs2022-xpu-2025_0-py3
     uses: ./.github/workflows/_win-build.yml
+    permissions:
+      contents: read
     with:
       build-environment: win-vs2022-xpu-py3
       cuda-version: cpu


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/288](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/288)

To fix the issue, we need to add an explicit `permissions` block to the `windows-xpu-2025_0-build` job. Based on the job's functionality, it likely only requires `contents: read` permissions to access repository contents. This change ensures that the job does not inherit unnecessary permissions from the repository, adhering to the principle of least privilege.

Steps:
1. Add a `permissions` block to the `windows-xpu-2025_0-build` job.
2. Set the permissions to `contents: read`, which is the minimal permission required for most CI workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
