### PR TITLE
Potential fix for code scanning alert no. 291: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3709,6 +3709,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13t-rocm6_3-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_13t-rocm6_3-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/291](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/291)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_13t-rocm6_3-test` job. Since this job is for testing, it likely only requires `contents: read` permissions. This change ensures that the job adheres to the principle of least privilege and avoids inheriting unnecessary permissions from the repository.

Steps:
1. Add a `permissions` block to the `manywheel-py3_13t-rocm6_3-test` job.
2. Set the permissions to `contents: read`, which is sufficient for testing tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
