### PR TITLE
Potential fix for code scanning alert no. 293: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -4546,6 +4546,8 @@ jobs:
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240
+    permissions:
+      contents: read
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       PACKAGE_TYPE: wheel


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/293](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/293)

To fix the issue, we need to add a `permissions` block to the `wheel-py3_12-xpu-build` job. This block should specify the least privileges required for the job. Based on the job's operations, it appears that only `contents: read` is necessary. This change will ensure that the `GITHUB_TOKEN` has limited access and adheres to security best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
