### PR TITLE
Potential fix for code scanning alert no. 296: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -4889,6 +4889,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_13-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_13-cpu-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/296](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/296)

To fix the issue, we need to add an explicit `permissions` block to the `wheel-py3_13-cpu-test` job. This block should specify the minimum permissions required for the job to function correctly. Based on the operations performed in the job, `contents: read` is sufficient, as the job primarily involves testing and does not require write access to the repository.

The changes should be made in the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_13-cpu-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
