### PR TITLE
Potential fix for code scanning alert no. 285: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3593,6 +3593,8 @@ jobs:
 
   manywheel-py3_13t-rocm6_2_4-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/285](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/285)

To fix the issue, add an explicit `permissions` block to the `manywheel-py3_13t-rocm6_2_4-build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the context, the job likely requires `contents: read` to access repository contents. If additional permissions are needed, they should be added explicitly.

The changes will involve:
1. Adding a `permissions` block to the `manywheel-py3_13t-rocm6_2_4-build` job.
2. Ensuring the permissions are scoped to the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
