### PR TITLE
Potential fix for code scanning alert no. 280: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -4067,6 +4067,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_12-cuda12_4-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/280](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/280)

To fix the issue, add a `permissions` block to the `wheel-py3_12-cuda12_4-build` job. This block should specify the least privileges required for the job. Based on the background information, most basic CI workflows only need `contents: read`. If additional permissions are required for specific actions, they should be added explicitly.

The changes will be made to the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_12-cuda12_4-build` job definition starting at line 4069.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
