### PR TITLE
Potential fix for code scanning alert no. 277: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3524,6 +3524,8 @@ jobs:
 
   manywheel-py3_13t-cuda12_6-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/277](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/277)

To fix the issue, we need to add an explicit `permissions` block to the `manywheel-py3_13t-cuda12_6-build` job. Based on the principle of least privilege, we should grant only the permissions required for the job to function. Since this job appears to be a build step, it likely only needs `contents: read` to access the repository's code. If additional permissions are required, they can be added after further analysis of the job's functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
