### PR TITLE
Potential fix for code scanning alert no. 278: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -3939,6 +3939,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_12-cuda11_8-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_12-cuda11_8-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/278](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/278)

To fix the issue, add an explicit `permissions` block to the `wheel-py3_12-cuda11_8-test` job. This block should specify the minimal permissions required for the job to function correctly. Based on the context, the job likely only needs `contents: read` permissions, as it primarily involves testing and downloading artifacts.

The changes should be made in the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_12-cuda11_8-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
