### PR TITLE
Potential fix for code scanning alert no. 277: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3692,6 +3692,8 @@ jobs:
 
   manywheel-py3_13t-rocm6_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/277](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/277)

To fix the issue, we will add an explicit `permissions` block to the `manywheel-py3_13t-rocm6_3-build` job. Since this job appears to be a build step and does not seem to require write access, we will set the permissions to `contents: read`, which is the minimal permission required for most CI workflows. This ensures that the job adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
