### PR TITLE
Potential fix for code scanning alert no. 279: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -108,6 +108,8 @@ jobs:
     if: ${{ always() && github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: read
     steps:
       - name: Get our GITHUB_TOKEN API limit usage
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/279](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/279)

To fix the issue, we need to add a `permissions` block to the `check-api-rate` job. Since the job only queries the API rate limit, it requires minimal permissions, specifically `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary access for the job and adheres to the principle of least privilege.

The changes will be made in the `.github/workflows/upload-test-stats.yml` file:
1. Add a `permissions` block to the `check-api-rate` job, specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
