### PR TITLE
Potential fix for code scanning alert no. 271: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -3594,6 +3594,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_12-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/271](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/271)

To fix the issue, we will add a `permissions` block to the `wheel-py3_12-cpu-build` job. Based on the job's functionality, it primarily involves building binaries and does not require write access to the repository. Therefore, we will set `contents: read` as the minimal permission. This change ensures that the job adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
