### PR TITLE
Potential fix for code scanning alert no. 274: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3455,6 +3455,8 @@ jobs:
 
   manywheel-py3_13t-cuda12_4-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/274](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/274)

To fix the issue, we will add a `permissions` block to the `manywheel-py3_13t-cuda12_4-build` job. Since this job appears to perform build-related tasks, it likely only requires `contents: read` permissions to access the repository's code. This change will ensure that the job does not inherit unnecessary permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
