### PR TITLE
Potential fix for code scanning alert no. 297: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -5499,6 +5499,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_13-cuda12_6-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/297](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/297)

To fix the issue, we need to add a `permissions` block to the `wheel-py3_13-cuda12_6-build` job. Based on the background information, the minimal permissions required for most CI workflows are `contents: read`. This ensures the job has only the necessary access to repository contents without granting write access or other elevated permissions.

The changes will be made to the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_13-cuda12_6-build` job definition starting at line 5501.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
