### PR TITLE
Potential fix for code scanning alert no. 270: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload-test-stats-while-running.yml
+++ b/.github/workflows/upload-test-stats-while-running.yml
@@ -1,5 +1,8 @@
 name: Upload test stats while running
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # Every hour


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/270](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/270)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's functionality, the `contents: read` permission is sufficient for most steps, and no write permissions are required. The `Upload test stats` step uses the `GITHUB_TOKEN`, but it does not appear to require write permissions, so `contents: read` should suffice.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `upload_test_stats_while_running` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
