### PR TITLE
Potential fix for code scanning alert no. 267: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3386,6 +3386,8 @@ jobs:
 
   manywheel-py3_13t-cuda11_8-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/267](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/267)

To fix the issue, we need to add an explicit `permissions` block to the affected job (`manywheel-py3_13t-cuda11_8-build` on line 3388). The permissions should be set to the minimum required for the job to function correctly. Based on the context of the job, it likely only needs `contents: read` permissions to access repository contents.

Steps:
1. Add a `permissions` block to the `manywheel-py3_13t-cuda11_8-build` job.
2. Set the permissions to `contents: read` to limit access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
