### PR TITLE
Potential fix for code scanning alert no. 261: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -3231,6 +3231,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_11-cuda12_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_11-cuda12_6-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/261](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/261)

To fix the issue, we will add a `permissions` block to the `wheel-py3_11-cuda12_6-test` job. This block will specify the minimal permissions required for the job to function. Based on the provided code, the job primarily involves testing and downloading artifacts, which typically require `contents: read`. No write permissions are necessary for this job.

The `permissions` block will be added immediately after the `if` condition on line 3233.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
