### PR TITLE
Potential fix for code scanning alert no. 281: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3552,6 +3552,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13t-cuda12_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_13t-cuda12_6-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/281](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/281)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_13t-cuda12_6-test` job. This block should specify the least privileges required for the job. Based on the job's description and context, it likely only needs `contents: read` permission to access repository contents.

Steps:
1. Add a `permissions` block to the `manywheel-py3_13t-cuda12_6-test` job.
2. Set `contents: read` as the permission, which is sufficient for most testing workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
