### PR TITLE
Potential fix for code scanning alert no. 268: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -3470,6 +3470,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_11-xpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_11-xpu-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/268](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/268)

To fix the issue, we will add a `permissions` block to the `wheel-py3_11-xpu-test` job. This block will explicitly set the permissions to the least privilege required for the job. Based on the job's steps, it does not appear to require any `write` permissions, so we will set `contents: read` as the minimal starting point.

The changes will be made to the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_11-xpu-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
