### PR TITLE
Potential fix for code scanning alert no. 298: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -5137,6 +5137,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_13-cuda11_8-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_13-cuda11_8-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/298](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/298)

To fix the issue, we need to add an explicit `permissions` block to the `wheel-py3_13-cuda11_8-test` job. Since this job primarily runs tests, it likely only requires `contents: read` permissions. This change ensures that the job adheres to the principle of least privilege and avoids inheriting unnecessary permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
