### PR TITLE
Potential fix for code scanning alert no. 269: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3410,6 +3410,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13t-cuda11_8-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_13t-cuda11_8-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/269](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/269)

To fix the issue, add an explicit `permissions` block to the job highlighted by CodeQL. This block should specify the minimal permissions required for the job to function correctly. Based on the context, the job likely only needs `contents: read` permissions, as it does not appear to perform write operations.

The `permissions` block should be added immediately after the `if` condition on line 3412. This ensures that the job explicitly limits the permissions of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
