### PR TITLE
Potential fix for code scanning alert no. 271: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -3835,6 +3835,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_12-cuda11_8-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/271](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/271)

To fix the issue, we need to add a `permissions` block to the `wheel-py3_12-cuda11_8-build` job. Based on the job's steps, it primarily involves building binaries and uploading artifacts, which typically require `contents: read` permissions. No write permissions are necessary unless explicitly required by the job's functionality.

The `permissions` block should be added directly under the job definition to ensure it applies only to this job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
