### PR TITLE
Potential fix for code scanning alert no. 262: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -3361,6 +3361,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_11-xpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/262](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/262)

To fix the issue, we will add a `permissions` block to the `wheel-py3_11-xpu-build` job. This block will explicitly define the minimal permissions required for the job. Based on the job's description and actions, it seems that only `contents: read` is necessary. This change will ensure that the job does not inherit unnecessary permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
