### PR TITLE
Potential fix for code scanning alert no. 263: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3256,6 +3256,8 @@ jobs:
 
   manywheel-py3_13t-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/263](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/263)

To fix the issue, add an explicit `permissions` block to the `manywheel-py3_13t-cpu-build` job. This block should define the minimal permissions required for the job to function correctly. Based on the context of the workflow, the job likely only needs `contents: read` permissions, as it appears to be a build step that does not require write access.

The changes should be made in the `.github/workflows/generated-linux-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_13t-cpu-build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
