### PR TITLE
Potential fix for code scanning alert no. 257: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/torchbench.yml
+++ b/.github/workflows/torchbench.yml
@@ -1,5 +1,8 @@
 name: torchbench
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/257](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/257)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are likely sufficient:
- `contents: read` to access repository contents.
- Additional permissions (e.g., `issues: write`, `pull-requests: write`) should only be added if the workflow explicitly requires them.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
