### PR TITLE
Potential fix for code scanning alert no. 259: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -3121,6 +3121,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_11-cuda12_6-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/259](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/259)

To fix the issue, we need to add an explicit `permissions` block to the job `wheel-py3_11-cuda12_6-build` on line 3123. This block should specify the least privileges required for the job to function correctly. Based on the background information, the minimal permissions required are `contents: read`. This ensures the workflow does not inherit excessive permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
