### PR TITLE
Potential fix for code scanning alert no. 263: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3323,6 +3323,8 @@ jobs:
 
   manywheel-py3_13t-cpu-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/263](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/263)

To fix the issue, we will add a `permissions` block to the `manywheel-py3_13t-cpu-cxx11-abi-build` job. Based on the job's purpose (building binaries), it likely only requires `contents: read` permissions to access the repository's code. This change will ensure the job does not inherit unnecessary write permissions from the repository's default settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
