### PR TITLE
Potential fix for code scanning alert no. 260: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [try-rebase]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   do_rebase:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/260](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/260)

To fix the issue, add a `permissions` block at the workflow level to define the minimal permissions required. Based on the workflow's operations, it primarily interacts with repository contents (e.g., checking out the repository and running scripts) and pull requests (e.g., commenting on PRs). Therefore, the `contents: read` and `pull-requests: write` permissions are sufficient. These permissions should be added at the root of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
