### PR TITLE
Potential fix for code scanning alert no. 249: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/target_determination.yml
+++ b/.github/workflows/target_determination.yml
@@ -3,6 +3,10 @@ name: target-determination
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
 
   get-label-type:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/249](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/249)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are likely sufficient:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with GitHub Actions.
- `id-token: write` if OpenID Connect tokens are required (not evident in this workflow).
- Additional permissions for specific actions (e.g., `packages: read`, `pull-requests: write`) if needed.

The `permissions` block can be added at the root level to apply to all jobs or at the job level for more granular control.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
