### PR TITLE
Potential fix for code scanning alert no. 246: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2989,6 +2989,8 @@ jobs:
       - manywheel-py3_13-rocm6_2_4-build
       - get-label-type
     runs-on: linux.rocm.gpu
+    permissions:
+      contents: read
     timeout-minutes: 240
     env:
       PYTORCH_ROOT: /pytorch


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/246](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/246)

To fix the issue, add a `permissions` block to the `manywheel-py3_13-rocm6_2_4-test` job. This block should specify the minimal permissions required for the job to function correctly. Based on the background information, the most basic permission is `contents: read`, which allows the job to read repository contents without granting write access.

The `permissions` block should be added directly under the job definition (`manywheel-py3_13-rocm6_2_4-test`) to ensure it applies only to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
