### PR TITLE
Potential fix for code scanning alert no. 292: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -4433,6 +4433,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_12-cuda12_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_12-cuda12_6-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/292](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/292)

To fix the issue, add a `permissions` block to the `wheel-py3_12-cuda12_6-test` job. This block should specify the least privileges required for the job to function correctly. Based on the background information, the minimal starting point is `contents: read`. If the job requires additional permissions, they should be added explicitly.

The changes will be made to the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_12-cuda12_6-test` job definition starting at line 4435.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
