### PR TITLE
Potential fix for code scanning alert no. 243: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2895,6 +2895,8 @@ jobs:
 
   manywheel-py3_13-cuda12_6-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/243](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/243)

To fix the issue, we need to explicitly define the permissions for the `manywheel-py3_13-cuda12_6-build` job. Since this job appears to be a build step, it likely only requires `contents: read` permissions to access the repository's code. We will add a `permissions` block to the job configuration to restrict its access to the minimum required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
