### PR TITLE
Potential fix for code scanning alert no. 229: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2647,6 +2647,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_13-cpu-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/229](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/229)

To fix the issue, add an explicit `permissions` block to the `manywheel-py3_13-cpu-test` job. This block should grant only the minimal permissions required for the job to function. Based on the context of the workflow, `contents: read` is likely sufficient, as the job appears to involve testing and does not require write access.

The changes should be made in the `.github/workflows/generated-linux-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_13-cpu-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
