### PR TITLE
Potential fix for code scanning alert no. 224: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2430,6 +2430,8 @@ jobs:
 
   manywheel-py3_12-rocm6_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/224](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/224)

To fix the issue, we need to add explicit permissions blocks to the jobs that lack them. The permissions should be scoped to the minimum required for each job. For example:
- Jobs that only need to read repository contents should have `contents: read`.
- Jobs that upload artifacts or interact with other GitHub features should have additional permissions as necessary.

The fix involves adding a `permissions` block to the `manywheel-py3_12-rocm6_3-build` job, as highlighted by CodeQL. This block will specify the least privileges required for the job to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
