### PR TITLE
Potential fix for code scanning alert no. 239: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -2755,6 +2755,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_11-cuda11_8-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_11-cuda11_8-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/239](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/239)

To fix the issue, we will explicitly define the `permissions` block for the `wheel-py3_11-cuda11_8-test` job. Based on the job's functionality, it only needs to read repository contents (e.g., for downloading artifacts and checking out the repository). Therefore, we will set `contents: read` as the minimal required permission.

The changes will be made to the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_11-cuda11_8-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
