### PR TITLE
Potential fix for code scanning alert no. 233: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2761,6 +2761,8 @@ jobs:
 
   manywheel-py3_13-cuda11_8-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/233](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/233)

To fix the issue, we will add a `permissions` block to the `manywheel-py3_13-cuda11_8-build` job. Based on the job's purpose (building binaries), it likely only requires `contents: read` permissions to access the repository's code. This change will ensure that the job does not inherit unnecessary write permissions from the repository's default settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
