### PR TITLE
Potential fix for code scanning alert no. 231: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -1,5 +1,9 @@
 name: Revert merged PR
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   repository_dispatch:
     types: [try-revert]


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/231](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/231)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimum required permissions. Based on the workflow's operations, the following permissions are likely sufficient:
- `contents: read` for checking out the repository.
- `pull-requests: write` for commenting on pull requests.

This ensures that the `GITHUB_TOKEN` is restricted to only the necessary permissions, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
