### PR TITLE
Potential fix for code scanning alert no. 230: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -2410,6 +2410,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_11-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/230](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/230)

To fix the issue, we will add an explicit `permissions` block to the `wheel-py3_11-cpu-build` job. Since this job appears to focus on building binaries and does not seem to require any `write` permissions, we will set the permissions to `contents: read`, which is the minimal required permission for most CI workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
