### PR TITLE
Potential fix for code scanning alert no. 227: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -2284,6 +2284,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_10-xpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_10-xpu-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/227](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/227)

To fix the issue, we will add an explicit `permissions` block to the `wheel-py3_10-xpu-test` job. Since this job primarily involves testing and does not require write access to the repository, we will set the permissions to `contents: read`. This ensures that the job has only the minimal permissions required to perform its tasks.

The changes will be made to the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_10-xpu-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
