### PR TITLE
Potential fix for code scanning alert no. 228: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2834,6 +2834,8 @@ jobs:
 
   manywheel-py3_13-cuda12_4-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/228](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/228)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_13-cuda12_4-build` job. Based on the job's functionality, it likely only requires `contents: read` permissions to access repository contents. This change ensures that the job does not inherit broader repository-level permissions, reducing the risk of unintended actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
