### PR TITLE
Potential fix for code scanning alert no. 224: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2527,6 +2527,8 @@ jobs:
 
   manywheel-py3_12-xpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/224](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/224)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_12-xpu-build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the context of the workflow, the job likely only needs `contents: read` to access the repository's contents. If additional permissions are required, they should be explicitly added.

The `permissions` block will be added immediately after the `if` condition on line 2529.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
