### PR TITLE
Potential fix for code scanning alert no. 242: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/runner_determinator_script_sync.yaml
+++ b/.github/workflows/runner_determinator_script_sync.yaml
@@ -1,5 +1,8 @@
 name: runner-determinator
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/242](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/242)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's operations (reading repository files and performing a diff), the `contents: read` permission is sufficient. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
