### PR TITLE
Potential fix for code scanning alert no. 237: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/runner-determinator-validator.yml
+++ b/.github/workflows/runner-determinator-validator.yml
@@ -9,6 +9,9 @@ on:
       - .github/scripts/runner_determinator.py
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/237](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/237)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only reads repository contents and does not perform any write operations, the permissions should be limited to `contents: read`. This ensures that the workflow has the minimum required access to complete its tasks securely.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs in the workflow. Alternatively, it can be added specifically to the `check-runner-determinator` job if other jobs in the workflow require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
