### PR TITLE
Potential fix for code scanning alert no. 219: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2266,6 +2266,8 @@ jobs:
 
   manywheel-py3_12-cuda12_6-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/219](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/219)

To fix the issue, we need to add an explicit `permissions` block to the `manywheel-py3_12-cuda12_6-build` job. Since this job appears to be a build step, it likely only requires `contents: read` permissions to access the repository's code. This change will ensure that the job does not inherit unnecessary permissions from the repository's default settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
