### PR TITLE
Potential fix for code scanning alert no. 218: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2219,6 +2219,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_12-cuda12_4-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_12-cuda12_4-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/218](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/218)

To fix the issue, we need to add an explicit `permissions` block to the `manywheel-py3_12-cuda12_4-test` job. Based on the nature of the job (testing), it likely only requires read access to repository contents. Therefore, the permissions block should specify `contents: read`. This change ensures that the job adheres to the principle of least privilege and avoids unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
