### PR TITLE
Potential fix for code scanning alert no. 215: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: update-commit-hash
     if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: write
     steps:
       - name: update-vision-commit-hash
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main
@@ -71,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: update-commit-hash
     if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: write
     steps:
       - name: update-audio-commit-hash
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main
@@ -86,6 +90,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: update-commit-hash
     if: ${{ github.event_name == 'schedule' && github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: write
     steps:
       - name: update-executorch-commit-hash
         uses: pytorch/test-infra/.github/actions/update-commit-hash@main


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/215](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/215)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the jobs to function correctly. For example:
- Jobs that interact with repository contents should have `contents: read`.
- Jobs that push changes or update commit hashes may require `contents: write`.
- Jobs using secrets should not require additional permissions beyond those explicitly defined.

The `permissions` block can be added at the workflow level (to apply to all jobs) or at the job level (to customize permissions for each job). In this case, job-specific permissions are recommended to ensure granular control.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
