### PR TITLE
Potential fix for code scanning alert no. 210: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2197,6 +2197,8 @@ jobs:
 
   manywheel-py3_12-cuda12_4-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/210](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/210)

To fix the issue, we will add a `permissions` block to the `manywheel-py3_12-cuda12_4-build` job. Since this job appears to be a build step, it likely only requires `contents: read` permissions to access the repository's code. We will explicitly set this minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
