### PR TITLE
Potential fix for code scanning alert no. 211: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   get-label-type:
     name: get-label-type
+    permissions:
+      contents: read
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     if: ${{ (github.event_name != 'schedule' || github.repository == 'pytorch/pytorch') && github.repository_owner == 'pytorch' }}
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/211](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/211)

To fix the issue, we need to add a `permissions` block to the `get-label-type` job. Based on the job's configuration, it does not appear to require write permissions, so we can set the permissions to `contents: read`. This ensures the job has the minimal access required to execute successfully.

The changes will be made in the `.github/workflows/nightly.yml` file, specifically within the `get-label-type` job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
