### PR TITLE
Potential fix for code scanning alert no. 209: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -1937,6 +1937,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_10-cuda12_6-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/209](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/209)

To fix the issue, we need to add an explicit `permissions` block to the `wheel-py3_10-cuda12_6-build` job. Based on the job's operations, it appears to primarily involve building binaries and interacting with the repository contents. Therefore, the minimal required permission is `contents: read`.

Steps to implement the fix:
1. Add a `permissions` block to the `wheel-py3_10-cuda12_6-build` job.
2. Set the permissions to `contents: read` to limit the scope of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
