### PR TITLE
Potential fix for code scanning alert no. 208: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2150,6 +2150,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_12-cuda11_8-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_12-cuda11_8-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/208](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/208)

To fix the issue, add a `permissions` block to the `manywheel-py3_12-cuda11_8-test` job. Based on the job's purpose (testing), it likely only requires `contents: read` permissions. This change ensures that the job does not inherit unnecessary permissions from the repository and adheres to the principle of least privilege.

The fix involves:
1. Adding a `permissions` block to the `manywheel-py3_12-cuda11_8-test` job.
2. Setting the permissions to `contents: read`, which is sufficient for most testing workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
