### PR TITLE
Potential fix for code scanning alert no. 198: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -1,5 +1,8 @@
 name: BC Lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/198](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/198)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since this is a linting job, it likely only requires read access to the repository contents. We will set `contents: read` as the minimal permission required. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
