### PR TITLE
Potential fix for code scanning alert no. 217: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -2049,6 +2049,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_10-cuda12_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_10-cuda12_6-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/217](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/217)

To fix the issue, we need to add an explicit `permissions` block to the `wheel-py3_10-cuda12_6-test` job. Based on the job's functionality, the minimal required permission is `contents: read`, which allows the job to read repository contents without granting unnecessary write access. This change ensures that the job adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
