### PR TITLE
Potential fix for code scanning alert no. 206: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2083,6 +2083,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_12-cpu-cxx11-abi-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_12-cpu-cxx11-abi-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/206](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/206)

To fix the issue, add an explicit `permissions` block to the `manywheel-py3_12-cpu-cxx11-abi-test` job. Since the job is primarily for testing, it likely only requires `contents: read` permissions. This change ensures that the job does not inherit unnecessary permissions from the repository or organization.

The fix involves:
1. Adding a `permissions` block to the job starting at line 2085.
2. Setting the permissions to `contents: read`, which is sufficient for most testing workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
