### PR TITLE
Potential fix for code scanning alert no. 213: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,6 +41,8 @@ jobs:
 
   docs-push:
     name: docs push
+    permissions:
+      contents: write
     uses: ./.github/workflows/_docs.yml
     needs:
       - docs-build


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/213](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/213)

To fix the issue, we need to add a `permissions` block to the `docs-push` job. Based on the job's functionality (pushing documentation), it likely requires `contents: write` permission. This permission allows the job to interact with the repository's contents, such as pushing changes. Other permissions should not be added unless explicitly required.

The `permissions` block should be added under the `docs-push` job definition, ensuring it has the least privileges necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
