### PR TITLE
Potential fix for code scanning alert no. 199: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -1702,6 +1702,8 @@ jobs:
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240
+    permissions:
+      contents: read
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       PACKAGE_TYPE: wheel


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/199](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/199)

To fix the issue, we need to add an explicit `permissions` block to the `wheel-py3_10-cuda12_4-build` job. Based on the job's functionality, it primarily involves building binaries, so it likely only requires `contents: read` permissions. This ensures the job has the minimal permissions necessary to complete its tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
