### PR TITLE
Potential fix for code scanning alert no. 232: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -2529,6 +2529,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_11-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_11-cpu-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/232](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/232)

To fix the issue, we will add an explicit `permissions` block to the `wheel-py3_11-cpu-test` job. Based on the job's functionality, it only requires `contents: read` permissions to access repository contents. This change will ensure that the job does not inherit unnecessary permissions and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
