### PR TITLE
Potential fix for code scanning alert no. 205: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2065,6 +2065,8 @@ jobs:
 
   manywheel-py3_12-cpu-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/205](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/205)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_12-cpu-cxx11-abi-build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the context of the workflow, the job likely only needs `contents: read` permissions to access repository contents.

Steps:
1. Add a `permissions` block to the `manywheel-py3_12-cpu-cxx11-abi-build` job.
2. Set `contents: read` as the permission, which is the least privilege required for most basic CI workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
