### PR TITLE
Potential fix for code scanning alert no. 201: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linux-aarch64.yml
+++ b/.github/workflows/linux-aarch64.yml
@@ -30,6 +30,8 @@ jobs:
     name: linux-jammy-aarch64-py3.10
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
+    permissions:
+      contents: read
     with:
       runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
       build-environment: linux-jammy-aarch64-py3.10


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/201](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/201)

To fix the issue, we need to add a `permissions` block to the `linux-jammy-aarch64-py3_10-build` job. This block should specify the least privileges required for the job to function correctly. Based on the workflow's context, the job likely requires `contents: read` to access repository contents. If additional permissions are needed, they should be added explicitly.

The fix involves:
1. Adding a `permissions` block to the `linux-jammy-aarch64-py3_10-build` job.
2. Setting `contents: read` as the default permission unless further analysis reveals additional requirements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
