### PR TITLE
Potential fix for code scanning alert no. 193: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -1461,6 +1461,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_10-cuda11_8-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/193](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/193)

To fix the issue, we need to add explicit `permissions` blocks to all jobs in the workflow that currently lack them. The permissions should be set to the minimum required for each job to function correctly. For jobs that do not require write access, we can use `permissions: { contents: read }`. For jobs that require specific write permissions, we should explicitly define those permissions.

The changes will be made to the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file. Each job will be reviewed, and a `permissions` block will be added where missing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
