### PR TITLE
Potential fix for code scanning alert no. 202: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1998,6 +1998,8 @@ jobs:
 
   manywheel-py3_12-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/202](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/202)

To fix the issue, we need to explicitly define the permissions for the `manywheel-py3_12-cpu-build` job. Based on the context of the workflow, the job likely requires minimal permissions, such as `contents: read`. This aligns with the principle of least privilege and ensures the job has only the necessary access.

The fix involves adding a `permissions` block to the `manywheel-py3_12-cpu-build` job, specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
