### PR TITLE
Potential fix for code scanning alert no. 194: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1801,6 +1801,8 @@ jobs:
 
   manywheel-py3_11-rocm6_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/194](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/194)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_11-rocm6_3-build` job. This block should specify the least privileges required for the job to function correctly. Based on the job's description and usage, it likely only requires `contents: read` permissions to access repository contents.

The changes will be made in the `.github/workflows/generated-linux-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_11-rocm6_3-build` job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
