### PR TITLE
Potential fix for code scanning alert no. 196: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -1573,6 +1573,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_10-cuda11_8-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_10-cuda11_8-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/196](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/196)

To fix the issue, we will add a `permissions` block to the job on line 1575. Since this job appears to involve testing and does not seem to require write access, we will set the permissions to `contents: read`, which is the minimal required permission for most workflows. This change ensures the job adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
