### PR TITLE
Potential fix for code scanning alert no. 190: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1706,6 +1706,8 @@ jobs:
 
   manywheel-py3_11-rocm6_2_4-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/190](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/190)

To fix the issue, add an explicit `permissions` block to the `manywheel-py3_11-rocm6_2_4-build` job. This block should grant only the minimal permissions required for the job to function correctly. Based on the job's context, it likely requires `contents: read` to access repository contents and no write permissions.

The fix involves:
1. Adding a `permissions` block to the `manywheel-py3_11-rocm6_2_4-build` job.
2. Setting `contents: read` as the minimal permission required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
