### PR TITLE
Potential fix for code scanning alert no. 191: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -1335,6 +1335,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_10-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_10-cpu-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/191](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/191)

To fix the issue, we will add an explicit `permissions` block to the `wheel-py3_10-cpu-test` job. Based on the job's description and steps, it appears that it only needs to read repository contents. Therefore, we will set `permissions: contents: read` for this job. This change will ensure that the job adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
