### PR TITLE
Potential fix for code scanning alert no. 186: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -1100,6 +1100,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_9-xpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_9-xpu-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/186](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/186)

To fix the issue, we need to add a `permissions` block to the `wheel-py3_9-xpu-test` job. This block should explicitly limit the permissions of the `GITHUB_TOKEN` to the least privileges required for the job. Based on the operations performed in the job, `contents: read` is sufficient, as the job involves downloading artifacts and running tests without modifying repository contents.

The changes should be made in the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_9-xpu-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
