### PR TITLE
Potential fix for code scanning alert no. 188: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1659,6 +1659,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_11-cuda12_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_11-cuda12_6-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/188](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/188)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_11-cuda12_6-test` job. This block should specify the least privileges required for the job to function correctly. Since the job is primarily for testing, it likely only requires `contents: read` permissions. 

The changes should be made in the `.github/workflows/generated-linux-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_11-cuda12_6-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
