### PR TITLE
Potential fix for code scanning alert no. 189: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -1228,6 +1228,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_10-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/189](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/189)

To fix the issue, we need to add an explicit `permissions` block to the `wheel-py3_10-cpu-build` job. Since this job primarily involves building binaries and does not require write access, the permissions should be limited to `contents: read`. This ensures the job adheres to the principle of least privilege while maintaining its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
