### PR TITLE
Potential fix for code scanning alert no. 197: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -3006,6 +3006,8 @@ jobs:
 
   manywheel-py3_13-rocm6_2_4-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/197](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/197)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_13-rocm6_2_4-build` job. This block should specify the least privileges required for the job to function correctly. Based on the context of the workflow, the job likely only needs `contents: read` permissions, as it appears to be a build step that does not require write access.

The fix involves:
1. Adding a `permissions` block to the `manywheel-py3_13-rocm6_2_4-build` job.
2. Ensuring the permissions are limited to `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
