### PR TITLE
Potential fix for code scanning alert no. 180: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1503,6 +1503,8 @@ jobs:
 
   manywheel-py3_11-cuda12_4-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/180](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/180)

To fix the issue, we will add a `permissions` block to the `manywheel-py3_11-cuda12_4-build` job. This block will specify the minimal permissions required for the job to function correctly. Based on the context of the workflow, the job likely only needs `contents: read` permissions to access the repository's contents. If additional permissions are required, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
