### PR TITLE
Potential fix for code scanning alert no. 173: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -786,6 +786,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   libtorch-cuda12_6-shared-with-deps-release-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/173](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/173)

To fix the issue, we will add a `permissions` block to the `libtorch-cuda12_6-shared-with-deps-release-build` job. This block will specify the minimal permissions required for the job to execute. Based on the job's steps, it primarily involves checking out the repository and running scripts, so `contents: read` should suffice. If additional permissions are required later, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
