### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -1,5 +1,11 @@
 name: windows-build
 
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+  issues: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/15](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/15)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are likely needed:
- `contents: read` for accessing repository contents.
- `issues: write` for interacting with issues (if applicable).
- `pull-requests: write` for interacting with pull requests (if applicable).
- `actions: read` for interacting with GitHub Actions artifacts.
- `id-token: write` for fetching OpenID Connect tokens (if applicable).

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within specific jobs if different jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
