### PR TITLE
Potential fix for code scanning alert no. 179: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -753,6 +753,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_9-cuda12_6-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/179](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/179)

To fix the issue, we will add a `permissions` block to the `wheel-py3_9-cuda12_6-build` job. This block will explicitly define the minimum required permissions for the job. Based on the workflow's purpose (building binaries), it is likely that only `contents: read` is needed. This ensures that the job has the least privilege necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
