### PR TITLE
Potential fix for code scanning alert no. 185: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1594,6 +1594,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_11-cuda12_4-full-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_11-cuda12_4-full-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/185](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/185)

To fix the issue, we will add an explicit `permissions` block to the `manywheel-py3_11-cuda12_4-full-test` job. Based on the principle of least privilege, we will start with `contents: read`, which is sufficient for most CI workflows unless additional permissions are required. If the job requires other specific permissions, they can be added explicitly.

The changes will be made to the `.github/workflows/generated-linux-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_11-cuda12_4-full-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
