### PR TITLE
Potential fix for code scanning alert no. 175: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -625,6 +625,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_9-cuda12_4-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_9-cuda12_4-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/175](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/175)

To fix the issue, add an explicit `permissions` block to the `wheel-py3_9-cuda12_4-test` job. Based on the job's functionality, it only requires read access to the repository contents. The permissions block should be set to `contents: read` to minimize privileges while allowing the job to function correctly.

The changes should be made in the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_9-cuda12_4-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
