### PR TITLE
Potential fix for code scanning alert no. 181: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1527,6 +1527,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_11-cuda12_4-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_11-cuda12_4-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/181](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/181)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_11-cuda12_4-test` job. Since this job appears to be a testing job, it likely does not require write permissions. A minimal `permissions` block with `contents: read` should suffice unless the job requires additional permissions. This change ensures that the job adheres to the principle of least privilege and avoids inheriting unnecessary permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
