### PR TITLE
Potential fix for code scanning alert no. 174: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1389,6 +1389,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_11-cpu-cxx11-abi-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_11-cpu-cxx11-abi-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/174](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/174)

To fix the issue, we need to add an explicit `permissions` block to the job `manywheel-py3_11-cpu-cxx11-abi-test` (line 1391). The permissions should be set to the minimum required for the job to function correctly. Based on the context, the job likely only needs `contents: read` permissions, as it appears to be a testing job and does not perform any write operations.

The fix involves:
1. Adding a `permissions` block to the job `manywheel-py3_11-cpu-cxx11-abi-test`.
2. Setting `contents: read` as the permission, which is the least privilege required for most CI workflows.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
