### PR TITLE
Potential fix for code scanning alert no. 164: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -387,6 +387,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_9-cuda11_8-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_9-cuda11_8-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/164](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/164)

To fix the issue, we need to add a `permissions` block to the `wheel-py3_9-cuda11_8-test` job. This block should specify the least privileges required for the job. Since the job primarily involves testing and does not appear to require write access, we can set `contents: read` as the minimal permission.

The changes should be made in the `.github/workflows/generated-windows-binary-wheel-nightly.yml` file, specifically within the `wheel-py3_9-cuda11_8-test` job definition. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
