### PR TITLE
Potential fix for code scanning alert no. 170: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1304,6 +1304,8 @@ jobs:
 
   manywheel-py3_11-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/170](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/170)

To fix the issue, we need to add an explicit `permissions` block to the `manywheel-py3_11-cpu-build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the nature of the job (building binaries), it likely only needs `contents: read` permissions to access repository files.

Steps to implement the fix:
1. Add a `permissions` block to the `manywheel-py3_11-cpu-build` job.
2. Set `contents: read` as the permission, as this is the minimal requirement for most CI workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
