### PR TITLE
Potential fix for code scanning alert no. 169: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -650,6 +650,9 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   libtorch-cuda12_4-shared-with-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
+      actions: read
     needs:
       - libtorch-cuda12_4-shared-with-deps-release-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/169](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/169)

To fix the issue, we will add a `permissions` block to the `libtorch-cuda12_4-shared-with-deps-release-test` job. This block will explicitly set the permissions to the minimum required for the job to function. Based on the job's steps, it primarily involves downloading artifacts, checking out the repository, and running scripts, so `contents: read` and `actions: read` should suffice.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
