### PR TITLE
Potential fix for code scanning alert no. 177: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1460,6 +1460,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_11-cuda11_8-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_11-cuda11_8-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/177](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/177)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_11-cuda11_8-test` job. Since this job is primarily for testing, it likely only requires `contents: read` permissions. This change ensures that the job adheres to the principle of least privilege and avoids relying on default repository-level permissions.

The fix involves:
1. Adding a `permissions` block to the `manywheel-py3_11-cuda11_8-test` job.
2. Setting the permissions to `contents: read`, which is sufficient for most testing workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
