### PR TITLE
Potential fix for code scanning alert no. 178: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -904,6 +904,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   libtorch-cuda12_6-shared-with-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - libtorch-cuda12_6-shared-with-deps-release-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/178](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/178)

To fix the issue, add a `permissions` block to the `libtorch-cuda12_6-shared-with-deps-release-test` job. This block should specify the least privileges required for the job to function correctly. Based on the operations performed in the job, `contents: read` is sufficient, as the job primarily interacts with repository contents and does not perform write operations.

The changes should be made in the `.github/workflows/generated-windows-binary-libtorch-release-nightly.yml` file, specifically within the `libtorch-cuda12_6-shared-with-deps-release-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
