### PR TITLE
Potential fix for code scanning alert no. 183: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1914,6 +1914,8 @@ jobs:
 
   manywheel-py3_11-xpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/183](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/183)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_11-xpu-build` job. This block should specify the least privileges required for the job. Based on the job's description and usage, it likely only needs `contents: read` permissions to access the repository's contents.

Steps to implement the fix:
1. Add a `permissions` block to the `manywheel-py3_11-xpu-build` job.
2. Set `contents: read` as the permission, as this is the minimal requirement for most CI workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
