### PR TITLE
Potential fix for code scanning alert no. 136: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-release-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-main.yml
@@ -4,6 +4,9 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: windows-binary-libtorch-release
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/136](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/136)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the provided workflow, it appears that the workflow primarily reads repository contents and does not perform any write operations. Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required for specific jobs, they can be defined at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
