### PR TITLE
Potential fix for code scanning alert no. 167: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -520,6 +520,8 @@ jobs:
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240
+    permissions:
+      contents: read
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       PACKAGE_TYPE: wheel


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/167](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/167)

To fix the issue, we need to add a `permissions` block to the `wheel-py3_9-cuda12_4-build` job. This block should specify the least privileges required for the job to function correctly. Based on the nature of the job (building binaries), it likely only requires `contents: read` permissions. This change ensures that the job does not inherit unnecessary permissions from the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
