### PR TITLE
Potential fix for code scanning alert no. 176: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1582,6 +1582,8 @@ jobs:
 
   manywheel-py3_11-cuda12_4-full-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/176](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/176)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_11-cuda12_4-full-build` job. Based on the job's purpose (building binaries), it likely only requires read access to repository contents. Therefore, the permissions should be set to `contents: read`.

Steps:
1. Locate the `manywheel-py3_11-cuda12_4-full-build` job definition starting at line 1584.
2. Add a `permissions` block specifying `contents: read` to limit the `GITHUB_TOKEN` permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
