### PR TITLE
Potential fix for code scanning alert no. 158: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1012,6 +1012,8 @@ jobs:
 
   manywheel-py3_10-rocm6_2_4-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/158](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/158)

To fix the issue, we need to add an explicit `permissions` block to the `manywheel-py3_10-rocm6_2_4-build` job. Since this job appears to be a build job, it likely only requires read access to the repository contents. We will set `contents: read` as the permission for this job.

The changes will be made in the `.github/workflows/generated-linux-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_10-rocm6_2_4-build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
