### PR TITLE
Potential fix for code scanning alert no. 212: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,6 +31,8 @@ jobs:
 
   docs-build:
     name: docs build
+    permissions:
+      contents: read
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/212](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/212)

To fix the issue, we need to add a `permissions` block to the `docs build` job. Since this job appears to only require read access to the repository contents (e.g., to fetch files for building documentation), we will set `contents: read` as the minimal required permission. This ensures the job does not inherit unnecessary write permissions from the repository.

The changes will be made in the `.github/workflows/nightly.yml` file, specifically within the `docs build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
