### PR TITLE
Potential fix for code scanning alert no. 159: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -537,6 +537,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   libtorch-cuda12_4-shared-with-deps-release-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/159](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/159)

To fix the issue, we need to add a `permissions` block to the `libtorch-cuda12_4-shared-with-deps-release-build` job. The permissions should be set to the least privilege required for the job to function correctly. Based on the workflow's context, the job likely only needs `contents: read` permissions, as it primarily involves building binaries and does not appear to require write access or other elevated permissions.

The changes will be made to the `.github/workflows/generated-windows-binary-libtorch-release-nightly.yml` file, specifically within the `libtorch-cuda12_4-shared-with-deps-release-build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
