### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -26,6 +26,10 @@ on:
         description: |
           A JSON description of what configs to run later on.
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   filter:
     if: github.repository_owner == 'pytorch'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/12](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/12)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's usage of the `GITHUB_TOKEN`, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with GitHub Actions artifacts.
- Additional permissions can be added if specific steps require them.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
