### PR TITLE
Potential fix for code scanning alert no. 151: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -874,6 +874,8 @@ jobs:
 
   manywheel-py3_10-cuda12_4-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/151](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/151)

To fix the issue, we need to add an explicit `permissions` block to the `manywheel-py3_10-cuda12_4-build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the nature of the job (building binaries), it likely only requires `contents: read` permissions.

Steps:
1. Add a `permissions` block to the `manywheel-py3_10-cuda12_4-build` job.
2. Set the permissions to `contents: read`, which is sufficient for most CI workflows unless additional permissions are explicitly required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
