### PR TITLE
Potential fix for code scanning alert no. 162: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -899,6 +899,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   libtorch-cuda12_6-shared-with-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - libtorch-cuda12_6-shared-with-deps-debug-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/162](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/162)

To fix the issue, we need to add a `permissions` block to the `libtorch-cuda12_6-shared-with-deps-debug-test` job. This block should specify the minimal permissions required for the job to function correctly. Based on the job's steps, it primarily involves downloading artifacts and checking out the repository, which only requires `contents: read`.

The `permissions` block should be added directly under the job definition (`libtorch-cuda12_6-shared-with-deps-debug-test`) to ensure it applies only to this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
