### PR TITLE
Potential fix for code scanning alert no. 150: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -4,6 +4,11 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: windows-binary-wheel
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 on:
   push:
     # NOTE: Meta Employees can trigger new nightlies using: https://fburl.com/trigger_pytorch_nightly_build


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/150](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/150)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are likely sufficient:
- `contents: read` for accessing repository contents.
- `issues: write` if the workflow interacts with issues (e.g., adding comments).
- `pull-requests: write` if the workflow interacts with pull requests (e.g., adding labels).

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
