### PR TITLE
Potential fix for code scanning alert no. 165: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -1379,6 +1379,8 @@ jobs:
 
   manywheel-py3_11-cpu-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/165](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/165)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_11-cpu-cxx11-abi-build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the context, the job likely only needs read access to repository contents. Therefore, we will set `contents: read` as the permission.

The changes will be made to the `.github/workflows/generated-linux-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_11-cpu-cxx11-abi-build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
