### PR TITLE
Potential fix for code scanning alert no. 131: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -380,6 +380,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_12-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     runs-on: macos-14-xlarge
     timeout-minutes: 240
     env:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/131](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/131)

To fix the issue, we need to explicitly define the `permissions` block for the `wheel-py3_12-cpu-build` job. Based on the job's steps, it primarily involves building and testing a PyTorch binary, which does not require write access to GitHub resources. Therefore, the minimal permissions of `contents: read` should suffice.

The `permissions` block should be added to the `wheel-py3_12-cpu-build` job definition, ensuring that the job adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
