### PR TITLE
Potential fix for code scanning alert no. 147: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -537,6 +537,8 @@ jobs:
     uses: ./.github/workflows/_binary-upload.yml
   libtorch-cuda12_4-shared-with-deps-debug-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/147](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/147)

To fix the issue, we will add a `permissions` block to the `libtorch-cuda12_4-shared-with-deps-debug-build` job. This block will explicitly define the minimum required permissions for the job. Based on the context of the workflow, the job likely only needs `contents: read` to access the repository's contents. If additional permissions are required, they can be added later after further analysis.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
