### PR TITLE
Potential fix for code scanning alert no. 141: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -4,6 +4,9 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: windows-binary-libtorch-release
 
+permissions:
+  contents: read
+
 on:
   push:
     # NOTE: Meta Employees can trigger new nightlies using: https://fburl.com/trigger_pytorch_nightly_build


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/141](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/141)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, it appears that the workflow primarily reads repository contents and metadata, so we will start with `contents: read`. If additional permissions are required for specific jobs, they can be added at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
