### PR TITLE
Potential fix for code scanning alert no. 135: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -291,6 +291,8 @@ jobs:
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"
     timeout-minutes: 240
+    permissions:
+      contents: read
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       PACKAGE_TYPE: libtorch


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/135](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/135)

To fix the issue, we need to add a `permissions` block to the `libtorch-cuda11_8-shared-with-deps-debug-build` job. This block should specify the least privileges required for the job. Based on the workflow's context, the job likely only needs read access to repository contents. Therefore, the permissions block should be set to `contents: read`.

The change should be made directly within the `libtorch-cuda11_8-shared-with-deps-debug-build` job definition, ensuring consistency with other jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
