### PR TITLE
Potential fix for code scanning alert no. 132: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -675,6 +675,8 @@ jobs:
 
   manywheel-py3_10-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/132](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/132)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_10-cpu-build` job. Based on the nature of the job, which appears to involve building binaries, it likely only requires read access to repository contents. Therefore, the permissions block should specify `contents: read`.

The changes will be made in the `.github/workflows/generated-linux-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_10-cpu-build` job definition starting at line 677.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
