### PR TITLE
Potential fix for code scanning alert no. 130: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-main.yml
@@ -4,6 +4,11 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: windows-binary-libtorch-debug
 
+permissions:
+  contents: read
+  actions: read
+  packages: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/130](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/130)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are likely sufficient:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with GitHub Actions artifacts.
- `packages: read` for handling packages if necessary.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is appropriate to ensure consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
