### PR TITLE
Potential fix for code scanning alert no. 127: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -4,6 +4,9 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: windows-binary-libtorch-debug
 
+permissions:
+  contents: read
+
 on:
   push:
     # NOTE: Meta Employees can trigger new nightlies using: https://fburl.com/trigger_pytorch_nightly_build


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/127](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/127)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient for most steps. If specific jobs require additional permissions, they can be defined within those jobs.

The `permissions` block should be added at the root level of the workflow to apply to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
