### PR TITLE
Potential fix for code scanning alert no. 120: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -323,6 +323,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13-cpu-s390x-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_13-cpu-s390x-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/120](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/120)

To fix the issue, we need to add an explicit `permissions` block to the `manywheel-py3_13-cpu-s390x-test` job. Based on the job's purpose (testing), it likely only requires `contents: read` permissions. This change ensures that the job does not inherit unnecessary permissions from the repository's default settings.

The `permissions` block should be added immediately after the `if` condition on line 325. No other changes are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
