### PR TITLE
Potential fix for code scanning alert no. 121: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -478,6 +478,8 @@ jobs:
 
   manywheel-py3_9-rocm6_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/121](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/121)

To fix the issue, we will add a `permissions` block to the `manywheel-py3_9-rocm6_3-build` job. Based on the context of the workflow, the job likely only needs `contents: read` permission to access repository contents. This aligns with the principle of least privilege and ensures the job has only the necessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
