### PR TITLE
Potential fix for code scanning alert no. 117: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -685,6 +685,8 @@ jobs:
 
   manywheel-py3_13t-cuda-aarch64-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/117](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/117)

To fix the issue, add an explicit `permissions` block to the `manywheel-py3_13t-cuda-aarch64-build` job. Based on the job's purpose (building binaries), it likely only requires read access to repository contents. Therefore, the permissions should be set to `contents: read`.

The changes should be made directly in the `.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml` file, within the `manywheel-py3_13t-cuda-aarch64-build` job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
