### PR TITLE
Potential fix for code scanning alert no. 116: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -4,6 +4,9 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: macos-arm64-binary-wheel
 
+permissions:
+  contents: read
+
 on:
 # TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/116](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/116)

To fix the issue, we need to explicitly define the `permissions` block at the workflow level or for individual jobs. Since most CI workflows only require `contents: read`, this should be the default permission unless a specific job requires additional permissions. For example, the `wheel-py3_9-cpu-upload` job already specifies `id-token: write` and `contents: read`, so no changes are needed there. For other jobs, we will add `permissions: contents: read` to limit the `GITHUB_TOKEN` permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
