### PR TITLE
Potential fix for code scanning alert no. 115: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -639,6 +639,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_13t-cpu-aarch64-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_13t-cpu-aarch64-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/115](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/115)

To fix the issue, we will add an explicit `permissions` block to the `manywheel-py3_13t-cpu-aarch64-test` job. Since this job appears to be a testing job, it likely only requires `contents: read` permissions. This change will ensure that the job does not inherit unnecessary permissions from the repository or workflow defaults.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
