### PR TITLE
Potential fix for code scanning alert no. 114: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -259,6 +259,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_12-cpu-s390x-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_12-cpu-s390x-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/114](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/114)

To fix the issue, we will add an explicit `permissions` block to the `manywheel-py3_12-cpu-s390x-test` job. Since this job is for testing, it likely only requires `contents: read` permissions. This change ensures that the job does not inherit unnecessary permissions from the repository's default settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
