### PR TITLE
Potential fix for code scanning alert no. 97: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -457,6 +457,8 @@ jobs:
 
   manywheel-py3_12-cuda-aarch64-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/97](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/97)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_12-cuda-aarch64-build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the job's description and usage, it likely only needs `contents: read` permissions to access repository contents.

The `permissions` block should be added directly under the job definition, ensuring it applies only to this specific job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
