### PR TITLE
Potential fix for code scanning alert no. 106: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -4,6 +4,8 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: linux-binary-manywheel
 
+permissions:
+  contents: read
 
 on:
   push:
@@ -314,6 +316,8 @@ jobs:
 
   manywheel-py3_9-cuda12_6-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:
@@ -336,6 +340,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_9-cuda12_6-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_9-cuda12_6-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/106](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/106)

To fix the issue, we need to add an explicit `permissions` block to the workflow or specific jobs within the workflow. The permissions should be set to the minimum required for the workflow's functionality. For example:
- If the job only needs to read repository contents, set `contents: read`.
- If the job requires write access for specific actions (e.g., uploading artifacts), set the corresponding permissions explicitly.

The fix involves adding a `permissions` block at the workflow level or job level, depending on the scope of the required permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
