### PR TITLE
Potential fix for code scanning alert no. 112: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -238,6 +238,8 @@ jobs:
 
   manywheel-py3_12-cpu-s390x-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/112](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/112)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_12-cpu-s390x-build` job. This block should specify the least privileges required for the job to function correctly. Based on the context of the workflow, the job likely only needs `contents: read` permissions to access repository contents. 

The fix involves:
1. Adding a `permissions` block to the `manywheel-py3_12-cpu-s390x-build` job.
2. Ensuring the permissions are limited to `contents: read` unless additional permissions are explicitly required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
