### PR TITLE
Potential fix for code scanning alert no. 95: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -258,6 +258,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   libtorch-cuda12_6-shared-with-deps-pre-cxx11-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - libtorch-cuda12_6-shared-with-deps-pre-cxx11-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/95](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/95)

To fix the issue, add a `permissions` block to the `libtorch-cuda12_6-shared-with-deps-pre-cxx11-test` job. Since this job is for testing, it likely only requires `contents: read` permissions. This change ensures that the job adheres to the principle of least privilege and avoids relying on default repository permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
