### PR TITLE
Potential fix for code scanning alert no. 91: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -4,6 +4,8 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: linux-s390x-binary-manywheel
 
+permissions:
+  contents: read
 
 on:
   push:
@@ -46,6 +48,8 @@ jobs:
       curr_ref_type: ${{ github.ref_type }}
   manywheel-py3_9-cpu-s390x-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:
@@ -67,6 +71,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_9-cpu-s390x-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_9-cpu-s390x-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/91](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/91)

To fix the issue, we will add an explicit `permissions` block to the workflow and its jobs. The permissions will be set to the minimum required for each job. For example:
- Jobs that only need to read repository contents will have `contents: read`.
- Jobs that require additional permissions (e.g., `id-token: write`) will retain those permissions.

The `permissions` block will be added at the workflow level for jobs that do not have specific requirements, and overridden at the job level where necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
