### PR TITLE
Potential fix for code scanning alert no. 85: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -193,6 +193,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   libtorch-cuda12_4-shared-with-deps-pre-cxx11-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - libtorch-cuda12_4-shared-with-deps-pre-cxx11-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/85](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/85)

To fix the issue, we need to add a `permissions` block to the affected job (`libtorch-cuda12_4-shared-with-deps-pre-cxx11-test`) to explicitly limit the permissions of the `GITHUB_TOKEN`. Based on the workflow's purpose (testing), the minimal required permissions are likely `contents: read`. This ensures the job has only the access it needs to perform its tasks.

The changes should be made directly in the `.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml` file, within the job definition for `libtorch-cuda12_4-shared-with-deps-pre-cxx11-test`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
