### PR TITLE
Potential fix for code scanning alert no. 79: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-manywheel-main.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-main.yml
@@ -4,6 +4,8 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: linux-binary-manywheel
 
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/79](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/79)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is likely sufficient for most jobs, as the workflow does not appear to require write access to the repository contents or other resources.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different jobs require different permissions. For simplicity and adherence to the principle of least privilege, we will add a root-level `permissions` block with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
