### PR TITLE
Potential fix for code scanning alert no. 98: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-macos-arm64-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-libtorch-cxx11-abi-nightly.yml
@@ -3,6 +3,8 @@
 # Template is at:    .github/templates/macos_binary_build_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: macos-arm64-binary-libtorch-cxx11-abi
+permissions:
+  contents: read
 
 on:
 # TODO: Migrate to new ciflow trigger, reference https://github.com/pytorch/pytorch/pull/70321


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/98](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/98)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply minimal permissions (`contents: read`) to all jobs by default. This ensures that the `GITHUB_TOKEN` has only the necessary permissions unless a specific job overrides it. Additionally, we will verify that the `libtorch-cpu-shared-with-deps-cxx11-abi-build` job does not require any additional permissions beyond `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
