### PR TITLE
Potential fix for code scanning alert no. 59: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -4,6 +4,10 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: linux-binary-libtorch-pre-cxx11
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/59](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/59)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the following permissions are likely sufficient:
- `contents: read` for accessing repository contents.
- `issues: write` if the workflow interacts with issues.
- `pull-requests: write` if the workflow interacts with pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
