### PR TITLE
Potential fix for code scanning alert no. 69: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -229,6 +229,8 @@ jobs:
 
   manywheel-py3_10-cuda-aarch64-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/69](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/69)

To fix the issue, add an explicit `permissions` block to the `manywheel-py3_10-cuda-aarch64-build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the background information, the most basic permission is `contents: read`. If the job requires additional permissions, they should be added explicitly.

The changes should be made in the `.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_10-cuda-aarch64-build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
