### PR TITLE
Potential fix for code scanning alert no. 64: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -303,6 +303,8 @@ jobs:
 
   libtorch-rocm6_2_4-shared-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/64](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/64)

To fix the issue, we need to add a `permissions` block to the `libtorch-rocm6_2_4-shared-with-deps-cxx11-abi-build` job. The permissions should be set to the least privilege required for the job to function correctly. Based on the job's description and usage, it likely only needs `contents: read` permissions to access repository contents.

Steps:
1. Add a `permissions` block to the `libtorch-rocm6_2_4-shared-with-deps-cxx11-abi-build` job.
2. Set the permissions to `contents: read` unless additional permissions are explicitly required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
