### PR TITLE
Potential fix for code scanning alert no. 62: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -183,6 +183,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   manywheel-py3_10-cpu-aarch64-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - manywheel-py3_10-cpu-aarch64-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/62](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/62)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_10-cpu-aarch64-test` job. This block should specify the least privileges required for the job to function correctly. Based on the context of the workflow, the minimal permissions required are likely `contents: read`. This aligns with the permissions set for other jobs in the workflow.

The changes will be made to the `.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_10-cpu-aarch64-test` job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
