### PR TITLE
Potential fix for code scanning alert no. 83: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -392,6 +392,8 @@ jobs:
 
   manywheel-py3_12-cpu-aarch64-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/83](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/83)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_12-cpu-aarch64-build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the context of the workflow and similar jobs, the `contents: read` permission is likely sufficient, as it allows the job to read repository contents without granting unnecessary write access.

The `permissions` block should be added immediately after the `if` condition on line 394.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
