### PR TITLE
Potential fix for code scanning alert no. 65: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -325,6 +325,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   libtorch-rocm6_2_4-shared-with-deps-cxx11-abi-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - libtorch-rocm6_2_4-shared-with-deps-cxx11-abi-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/65](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/65)

To fix the issue, we need to explicitly define the permissions for the job `libtorch-rocm6_2_4-shared-with-deps-cxx11-abi-test`. Based on the operations performed in the job, the minimal required permission is `contents: read`. This ensures that the job has only the necessary access to repository contents and avoids granting excessive permissions.

The fix involves adding a `permissions` block to the job definition, specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
