### PR TITLE
Potential fix for code scanning alert no. 58: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -160,6 +160,8 @@ jobs:
 
   manywheel-py3_10-cpu-aarch64-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/58](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/58)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_10-cpu-aarch64-build` job. This block should specify the minimal permissions required for the job to function correctly. Based on the context of the workflow, the job likely requires read access to the repository contents (`contents: read`). If additional permissions are needed, they should be added explicitly.

The changes will be made in the `.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_10-cpu-aarch64-build` job definition starting at line 162.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
