### PR TITLE
Potential fix for code scanning alert no. 73: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -514,6 +514,8 @@ jobs:
 
   manywheel-py3_13-cpu-aarch64-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/73](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/73)

To fix the issue, we need to add a `permissions` block to the `manywheel-py3_13-cpu-aarch64-build` job. This block should specify the least privileges required for the job to function correctly. Based on the context of similar jobs in the workflow, the minimal permissions required are likely `contents: read`. This ensures the job can read repository contents without granting unnecessary write access.

The changes will be made to the `.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml` file, specifically within the `manywheel-py3_13-cpu-aarch64-build` job definition starting at line 516.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
