### PR TITLE
Potential fix for code scanning alert no. 49: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-main.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-main.yml
@@ -4,6 +4,8 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: linux-binary-libtorch-pre-cxx11
 
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/49](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/49)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the `contents: read` permission is likely sufficient, as the workflow does not appear to modify repository contents or perform other write operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different permissions are required for each job. In this case, adding it at the root level is appropriate since all jobs seem to share similar requirements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
