### PR TITLE
Potential fix for code scanning alert no. 54: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -1,5 +1,8 @@
 name: Build manywheel docker images
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/54](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/54)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, such as interacting with repository contents and Docker registries, we will set `contents: read` as the default permission. If any specific jobs require additional permissions, they can override the root-level permissions with their own `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
