### PR TITLE
Potential fix for code scanning alert no. 55: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -4,6 +4,8 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: linux-binary-libtorch-cxx11-abi
 
+permissions:
+  contents: read
 
 on:
   push:
@@ -173,6 +175,8 @@ jobs:
 
   libtorch-cuda12_4-shared-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_binary-build-linux.yml
     needs: get-label-type
     with:
@@ -193,6 +197,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   libtorch-cuda12_4-shared-with-deps-cxx11-abi-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - libtorch-cuda12_4-shared-with-deps-cxx11-abi-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/55](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/55)

To fix the issue, we need to add a `permissions` block to the workflow or specific jobs to restrict the `GITHUB_TOKEN` permissions to the minimum required. Based on the workflow's functionality, the most appropriate permissions are likely `contents: read`. This ensures the workflow can access repository contents without granting unnecessary write permissions.

The fix involves:
1. Adding a `permissions` block at the root level of the workflow to apply to all jobs.
2. Alternatively, adding job-specific `permissions` blocks for jobs that require different levels of access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
