### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -4,6 +4,8 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: linux-aarch64-binary-manywheel
 
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/31](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/31)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the most likely required permission is `contents: read`, as the workflow appears to involve reading repository contents but does not explicitly indicate any write operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different jobs require different permissions. In this case, adding it at the root level is sufficient and simplifies the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
