### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-main.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-main.yml
@@ -4,6 +4,8 @@
 # Generation script: .github/scripts/generate_ci_workflows.py
 name: linux-binary-libtorch-cxx11-abi
 
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/36](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/36)

To fix the issue, add a `permissions` block at the root level of the workflow to define the least privileges required. Based on the workflow's operations, it primarily interacts with repository contents and uses the `GITHUB_TOKEN` for authentication. Therefore, the minimal permissions should be `contents: read`. If additional permissions are required for specific jobs, they can be defined within those jobs.

Steps:
1. Add a `permissions` block at the root level of the workflow.
2. Set `contents: read` as the default permission for all jobs.
3. If specific jobs require additional permissions (e.g., `issues: write` or `pull-requests: write`), define them within the respective job blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
