### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/close-nonexistent-disable-issues.yml
+++ b/.github/workflows/close-nonexistent-disable-issues.yml
@@ -1,5 +1,8 @@
 name: Close nonexistent disable issues
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: 5 22 * * 5  # this should be about 3PM PT on Friday


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/29](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/29)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not appear to require write access, we can set the permissions to `contents: read`, which is sufficient for most basic CI workflows. This ensures that the `GITHUB_TOKEN` has minimal privileges, reducing the risk of misuse.

The `permissions` block should be added at the root level of the workflow, applying to all jobs. Alternatively, it can be added specifically to the `close-nonexistent-disable-issues` job if other jobs in the workflow require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
