### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-manywheel-images-s390x.yml
+++ b/.github/workflows/build-manywheel-images-s390x.yml
@@ -1,5 +1,8 @@
 name: Build manywheel docker images for s390x
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/22](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/22)

To fix the issue, we will add a `permissions` block at the workflow level to define the least privileges required. Based on the workflow's operations, it primarily needs to read repository contents. If the `WITH_PUSH` step is executed, it uses secrets for Docker authentication, so no additional permissions are required for that step. We will set `contents: read` as the minimal permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
