### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -39,6 +39,8 @@ jobs:
 
   build-wheel:
     name: "Build Triton Wheel"
+    permissions:
+      contents: read
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge"
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/24](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/24)

To fix the issue, we will add a `permissions` block to the `build-wheel` job. Based on the job's actions, it likely only requires `contents: read` to access the repository's files. This change will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required for the job to function correctly.

The `permissions` block will be added directly under the `build-wheel` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
