### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [try-cherry-pick]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   cherry-pick:
     name: cherry-pick-pr-${{ github.event.client_payload.pr_num }}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/28](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/28)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimal permissions required. Based on the workflow's operations, it primarily needs to read repository contents and possibly write pull request metadata (e.g., labels or comments). We will set `contents: read` and `pull-requests: write` as the permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
