### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -1,5 +1,8 @@
 name: Build libtorch docker images
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/19](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/19)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations (e.g., interacting with Docker images, using secrets, and calculating Docker image names), the minimal permissions required are likely `contents: read`. If the workflow needs to write to the repository or perform other actions, additional permissions can be added as needed.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, or it can be added to individual jobs if different jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
