### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -1,5 +1,12 @@
 name: mac-test
 
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull-requests: write
+  packages: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/11](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/11)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are likely needed:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with GitHub Actions artifacts.
- `issues: write` for checking labels and re-enabled test issues.
- `pull-requests: write` for operations related to pull requests.
- `packages: read` for downloading build artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `test` job. In this case, adding it at the root level is recommended for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
