### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -1,5 +1,9 @@
 name: bazel
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/2](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow uses the `GITHUB_TOKEN` for actions like checking out the repository and interacting with the workflow, we will assign the minimal required permissions. Specifically:
- `contents: read` is needed for accessing the repository contents.
- `actions: read` is needed for interacting with workflows and artifacts.
- Additional permissions will be added only if required by specific steps.

The `permissions` block will be added at the workflow level to apply to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
