### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -1,5 +1,9 @@
 name: mac-build
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/9](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/9)

To fix the issue, add a `permissions` block at the root level of the workflow to explicitly define the least privileges required. Based on the workflow's functionality, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with GitHub Actions artifacts.
- `id-token: write` if OpenID Connect tokens are required (not evident in this workflow).
- Additional permissions can be added if specific steps require them.

The `permissions` block should be added at the top of the workflow file, ensuring all jobs inherit these permissions unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
