### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -1,5 +1,8 @@
 name: Build almalinux docker images
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/16](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the workflow's tasks, it primarily interacts with repository contents (e.g., checking out code) and uses secrets for Docker authentication. Therefore, the `contents: read` permission is sufficient for most steps, and no write permissions are required. If additional permissions are needed for specific steps, they can be added to the relevant job or step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
