### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -1,5 +1,11 @@
 name: linux-test
 
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+  packages: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/7](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimal permissions required. Based on the workflow's usage of the `GITHUB_TOKEN`, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with workflows and artifacts.
- `pull-requests: write` for adding labels to pull requests (used in the `filter-test-configs` step).
- `packages: read` for accessing packages if needed.

This ensures that the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
