### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -1,5 +1,8 @@
 name: linux-binary-build
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/3](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's operations, the minimal permissions required are `contents: read`. This will ensure that the `GITHUB_TOKEN` is limited to read-only access to the repository contents, unless additional permissions are explicitly required for specific jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
