### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -1,5 +1,10 @@
 name: win-test
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/14](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/14)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are likely needed:
- `contents: read` for accessing repository contents.
- `issues: write` for interacting with issues (if applicable).
- `pull-requests: write` for interacting with pull requests (if applicable).

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
