### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -1,5 +1,10 @@
 name: linux-build
 
+permissions:
+  contents: read
+  actions: read
+  statuses: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/8](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's usage of the `GITHUB_TOKEN`, the following permissions are likely sufficient:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with GitHub Actions metadata.
- `statuses: write` for updating commit statuses if necessary.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions to that specific job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
