### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -1,4 +1,6 @@
 name: linux-binary-test
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/4](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, such as checking out the repository and downloading artifacts, the `contents: read` permission is sufficient. If additional permissions are required for specific steps, they can be added to the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
