### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -30,6 +30,8 @@ jobs:
   get-label-type:
     if: github.repository_owner == 'pytorch'
     name: get-label-type
+    permissions:
+      contents: read
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:
       triggering_actor: ${{ github.triggering_actor }}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/23](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/23)

To fix the issue, we need to add a `permissions` block to the `get-label-type` job. This block should specify the least privileges required for the job to function correctly. Since the job uses a reusable workflow, we assume it only needs `contents: read` permissions unless additional permissions are explicitly required by the reusable workflow.

The fix involves:
1. Adding a `permissions` block to the `get-label-type` job.
2. Setting `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
