### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -19,6 +19,8 @@ jobs:
   get-label-type:
     if: github.repository_owner == 'pytorch'
     name: get-label-type
+    permissions:
+      contents: read
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:
       triggering_actor: ${{ github.triggering_actor }}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/30](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/30)

To fix the issue, we need to add a `permissions` block to the `get-label-type` job. Since this job does not appear to require write access to any resources, we can set the permissions to `contents: read`, which is the minimal permission required for most workflows. This ensures the job adheres to the principle of least privilege.

The changes will be made in the `.github/workflows/create_release.yml` file, specifically within the `get-label-type` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
