### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_mergeability_ghstack.yml
+++ b/.github/workflows/check_mergeability_ghstack.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize, reopened]
     branches: [gh/**/base]
 
+permissions:
+  contents: read
+
 jobs:
   ghstack-mergeability-check:
     if: github.repository_owner == 'pytorch'


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/25](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/25)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it primarily reads repository contents and uses the `GITHUB_TOKEN` for mergeability checks. Therefore, the `contents: read` permission is sufficient.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. This ensures that the `GITHUB_TOKEN` is restricted across the entire workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
