### PR TITLE
Potential fix for code scanning alert no. 284: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -15,6 +15,8 @@ jobs:
   get-label-type:
     if: github.repository_owner == 'pytorch'
     name: get-label-type
+    permissions:
+      contents: read
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
     with:
       triggering_actor: ${{ github.triggering_actor }}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/284](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/284)

To fix the issue, we will add a `permissions` block to the `get-label-type` job. Based on the job's functionality (retrieving label type information), it likely only requires `contents: read` permissions. This ensures that the job has the minimal permissions necessary to perform its task, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
