### PR TITLE
Potential fix for code scanning alert no. 314: Incomplete regular expression for hostnames

### DIFF
--- a/benchmarks/dynamo/parse_logs.py
+++ b/benchmarks/dynamo/parse_logs.py
@@ -20,7 +20,7 @@ full_log = open(sys.argv[1]).read()
 
 # If the log contains a gist URL, extract it so we can include it in the CSV
 gist_url = ""
-m = re.search(r"https://gist.github.com/[a-f0-9]+", full_log)
+m = re.search(r"https://gist\.github\.com/[a-f0-9]+", full_log)
 if m is not None:
     gist_url = m.group(0)
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/314](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/314)

To fix the issue, the `.` meta-character in the regular expression should be escaped to ensure it matches only a literal `.`. This makes the regex more precise and prevents unintended matches. Specifically, the regex `https://gist.github.com/[a-f0-9]+` should be updated to `https://gist\.github\.com/[a-f0-9]+`.

The change should be made in the file `benchmarks/dynamo/parse_logs.py` on line 23. No additional imports or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
