### PR TITLE
Potential fix for code scanning alert no. 307: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -6726,6 +6726,8 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
   wheel-py3_13t-cuda12_8-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
+    permissions:
+      contents: read
     needs:
       - wheel-py3_13t-cuda12_8-build
       - get-label-type


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/307](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/307)

To fix the problem, you should add a `permissions` block to the `wheel-py3_13t-cuda12_8-test` job (starting at line 6728). This block should restrict the job's permissions to the minimum required, which, unless this job uploads or modifies contents or uses OIDC, is typically `contents: read`. The block should be inserted right after the job name and before other keys (such as `needs`, `runs-on`, etc.). This will ensure that the job does not receive unnecessary write permissions and follows the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
