### PR TITLE
Potential fix for code scanning alert no. 310: Implicit narrowing conversion in compound assignment

### DIFF
--- a/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
@@ -392,7 +392,7 @@ public abstract class Tensor {
   /** Calculates the number of elements in a tensor with the specified shape. */
   public static long numel(long[] shape) {
     checkShape(shape);
-    int result = 1;
+    long result = 1;
     for (long s : shape) {
       result *= s;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/310](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/310)

To fix the issue, we need to ensure that the type of `result` is wide enough to handle the multiplication without risking overflow or data loss. Since `s` is of type `long`, changing the type of `result` from `int` to `long` would eliminate the implicit narrowing conversion. This change ensures that the product of `result` and `s` is computed and stored safely without requiring a narrowing cast.

The required changes are:
1. Update the declaration of `result` from `int` to `long`.
2. Ensure that all related operations and return types remain consistent with the updated type.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
