### PR TITLE
Potential fix for code scanning alert no. 308: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -6854,6 +6854,8 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
     uses: ./.github/workflows/_binary-upload.yml
   wheel-py3_13t-xpu-build:
+    permissions:
+      contents: read
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: get-label-type
     runs-on: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge"


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/308](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/308)

To address the problem, explicitly set a minimal `permissions` block for the `wheel-py3_13t-xpu-build` job in `.github/workflows/generated-windows-binary-wheel-nightly.yml`. The safest starting point is to grant only `contents: read`, which is usually sufficient for most build/test jobs unless they need to write to issues, PRs, or use OIDC tokens for artifact uploads. This mirrors the approach taken in other jobs within the same workflow. The change should be made by adding the following lines to the job definition:

```yaml
permissions:
  contents: read
```

This should be added at the correct indentation level, immediately after the job name (after line 6856 and before line 6857). No additional imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
