### PR TITLE
Potential fix for code scanning alert no. 279: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -58,6 +58,8 @@ jobs:
     if: github.repository_owner == 'pytorch'
     name: win-vs2022-xpu-2025_0-py3
     uses: ./.github/workflows/_win-build.yml
+    permissions:
+      contents: read
     with:
       build-environment: win-vs2022-xpu-py3
       cuda-version: cpu


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/279](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/279)

To fix the problem, we should add a `permissions` block to the `windows-xpu-2025_0-build` job, restricting the `GITHUB_TOKEN` to the minimum necessary permissions. If the job only needs read access to the repository contents, set `contents: read`. If it needs additional permissions, add those as needed. Based on the analogous jobs in the workflow, starting with `contents: read` seems appropriate. The change should be made within the job definition for `windows-xpu-2025_0-build` in `.github/workflows/xpu.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
