### PR TITLE
Potential fix for code scanning alert no. 283: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -108,6 +108,8 @@ jobs:
   check-api-rate:
     if: ${{ always() && github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     continue-on-error: true
     steps:
       - name: Get our GITHUB_TOKEN API limit usage


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/283](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/283)

The most appropriate fix is to explicitly define a `permissions` block for the `check-api-rate` job. Since this job only queries the API rate limit and does not perform any write operations, it should be assigned the minimal permissions of `contents: read`. This change will ensure the job adheres to the principle of least privilege and prevent it from unnecessarily inheriting the repository's default permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
