### PR TITLE
Potential fix for code scanning alert no. 281: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -12,6 +12,8 @@ jobs:
   get_workflow_conclusion:
     if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       conclusion: ${{ fromJson(steps.get_conclusion.outputs.data).conclusion }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/281](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/281)

To address the issue, we will add a `permissions` block to the `get_workflow_conclusion` job. This block will explicitly declare the minimal permissions required for the job. Based on the current functionality, the job only involves retrieving workflow run data via the GitHub API. Hence, the `contents: read` permission should suffice. We will ensure no unnecessary `write` permissions are granted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
