### PR TITLE
Potential fix for code scanning alert no. 278: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -24,6 +24,8 @@ jobs:
 
   linux-jammy-xpu-2025_0-py3_9-build:
     name: linux-jammy-xpu-2025.0-py3.9
+    permissions:
+      contents: read
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/278](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/278)

To fix the problem, we should explicitly set the least required permissions for the job `linux-jammy-xpu-2025_0-py3_9-build`. Since the job uses a build workflow and, unless it needs to push changes or create pull requests, it typically only needs read access to repository contents. Add a `permissions` block to the job, setting `contents: read` as a minimal starting point. Insert the block directly below the `name:` key (line 26) and above the `uses:` key (line 27) in the job definition. No other code changes or imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
