### PR TITLE
Potential fix for code scanning alert no. 277: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -15,6 +15,8 @@ jobs:
   get-label-type:
     if: github.repository_owner == 'pytorch'
     name: get-label-type
+    permissions:
+      contents: read
     uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@release/2.7
     with:
       triggering_actor: ${{ github.triggering_actor }}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/277](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/277)

The best fix is to add a `permissions` block to the `get-label-type` job, specifying the least privileges required. Since the job is retrieving label type information, it likely only needs read access to repository contents. We will add `permissions: contents: read` to the job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
