### PR TITLE
Potential fix for code scanning alert no. 271: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload-test-stats-while-running.yml
+++ b/.github/workflows/upload-test-stats-while-running.yml
@@ -1,9 +1,13 @@
 name: Upload test stats while running
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   schedule:
     # Every hour
-    - cron: '0 * * * *'
+   - cron: '0 * * * *'
 
 concurrency:
   group: upload-test-stats-while-running


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/271](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/271)

To fix this issue, we need to add a `permissions` block to the workflow. The permissions should be explicitly scoped to only the resources required to complete the tasks in the workflow. Based on the tasks performed in the workflow, we can limit the permissions to read-only for repository contents (`contents: read`) and write permissions for pulling requests or uploading statistics if necessary.

The `permissions` block should be added at the workflow level (root) to apply to all jobs unless a job-specific `permissions` block overrides it. Alternatively, we can add the `permissions` block to the specific job (`upload_test_stats_while_running`) if that job has unique permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
