### PR TITLE
Potential fix for code scanning alert no. 269: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -1,5 +1,9 @@
 name: Rebase PR
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   repository_dispatch:
     types: [try-rebase]


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/269](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/269)

The fix involves adding a `permissions` block to the workflow to explicitly define the least privileges required for the tasks performed in the job. Based on the operations in the provided workflow, the following permissions are minimally required:

1. **contents: read** — Required for read-only access to the repository content.
2. **pull-requests: write** — Required for writing comments on pull requests and potentially updating pull requests during the rebase process.

The `permissions` block will be added at the root of the workflow file, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
