### PR TITLE
Potential fix for code scanning alert no. 265: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/torchbench.yml
+++ b/.github/workflows/torchbench.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: torchbench
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/265](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/265)

To fix the issue, add an explicit `permissions` block to the workflow file to limit the `GITHUB_TOKEN` permissions according to the principle of least privilege. The safest minimal default is usually `contents: read`, unless the workflow needs to write to the repository or interact with issues or pull requests. Since the provided jobs do not appear to perform any write operations (they use reusable workflows for builds and tests), setting the root-level permissions to read-only is appropriate. This change should be made at the top level of the workflow file, just below the `name` field (after line 1), so it applies to all jobs unless overridden. No new methods, imports, or definitions are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
