### PR TITLE
Potential fix for code scanning alert no. 267: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-check-binary.yml
+++ b/.github/workflows/test-check-binary.yml
@@ -7,6 +7,9 @@ on:
       - .ci/pytorch/check_binary.sh
       - .ci/pytorch//smoke_test/smoke_test.py
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/267](https://github.com/Git-Hub-Chris/PyTorch/security/code-scanning/267)

To fix this issue, we need to add an explicit `permissions` block to the workflow. Since the jobs in this workflow primarily run scripts and install dependencies, they likely only require `contents: read` permissions, which provide read-only access to the repository contents. We will add the `permissions` block at the root level of the workflow to apply the same permissions to all jobs unless overridden at the job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
